### PR TITLE
Vkormushkin/dev

### DIFF
--- a/kdoctor/build.gradle.kts
+++ b/kdoctor/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     kotlin("multiplatform")
+    kotlin("plugin.serialization") version "1.6.10"
 }
 
 kotlin {
@@ -17,14 +18,14 @@ kotlin {
             dependencies {
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0-native-mt")
                 implementation("org.jetbrains.kotlinx:kotlinx-cli:0.3.4")
+                implementation ("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.2")
+
             }
         }
         val macosX64Main by getting
         val macosArm64Main by getting
         val macosMain by creating {
-            dependencies {
-                implementation ("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.2")
-            }
+
         }
 
         /* Main hierarchy */

--- a/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/diagnostics/CocoapodsDiagnostic.kt
+++ b/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/diagnostics/CocoapodsDiagnostic.kt
@@ -91,8 +91,8 @@ class CocoapodsDiagnostic : Diagnostic("Cocoapods") {
 
         messages.addSuccess("${cocoapodsGenerate.name} (${cocoapodsGenerate.version})")
 
-        val locale = System.getEnvVar("LC_CTYPE")
-        if (locale == null || !locale.contains("UTF-8")) {
+        val locale = System.execute("/usr/bin/locale", "-k", "LC_CTYPE", "") //trailing empty arg is required
+        if (locale.output == null || !locale.output.contains("UTF-8")) {
             val hint = """
             Consider adding the following to ${System.getShell()?.profile ?: "shell profile"}
             export LC_ALL=en_US.UTF-8

--- a/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/diagnostics/JavaDiagnostic.kt
+++ b/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/diagnostics/JavaDiagnostic.kt
@@ -11,7 +11,8 @@ class JavaDiagnostic : Diagnostic("Java") {
     override fun runChecks(): List<Message> {
         val messages = mutableListOf<Message>()
         var javaLocation = System.execute("which", "java").output
-        val javaVersion = System.execute("java", "--version").output?.lineSequence()?.firstOrNull()
+        val javaVersionCmd = System.execute("java", "-version")
+        val javaVersion = if (javaVersionCmd.code == 0) javaVersionCmd.error?.lineSequence()?.firstOrNull() else null
         //java_home requires empty argument, returns empty response otherwise
         val systemJavaHome = System.execute("/usr/libexec/java_home", "").output
         val javaHome = System.getEnvVar("JAVA_HOME")

--- a/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/entity/ToolboxHistory.kt
+++ b/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/entity/ToolboxHistory.kt
@@ -1,0 +1,12 @@
+package org.jetbrains.kotlin.doctor.entity
+
+import kotlinx.serialization.*
+
+@Serializable
+data class ToolboxItem(val id: String, val build: String) //consider fields valuable for KDoctor only
+
+@Serializable
+data class ToolboxHistoryEntry(val action: String, val item: ToolboxItem, val timestamp: String)
+
+@Serializable
+data class ToolboxHistory(val history: List<ToolboxHistoryEntry>)


### PR DESCRIPTION
Fixes:
* Fixed the case when LC_CTYPE env var is empty but there is still a value in locale settings
* Use -version instead --version for getting java version cause the last is not supported by JAVA 8
* Filter off Toolbox backup versions of Android Studio