### PR TITLE
Fixed sporadic errors while executing a shell command

### DIFF
--- a/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/diagnostics/CocoapodsDiagnostic.kt
+++ b/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/diagnostics/CocoapodsDiagnostic.kt
@@ -91,7 +91,7 @@ class CocoapodsDiagnostic : Diagnostic("Cocoapods") {
 
         messages.addSuccess("${cocoapodsGenerate.name} (${cocoapodsGenerate.version})")
 
-        val locale = System.execute("/usr/bin/locale", "-k", "LC_CTYPE", "") //trailing empty arg is required
+        val locale = System.execute("/usr/bin/locale", "-k", "LC_CTYPE")
         if (locale.output == null || !locale.output.contains("UTF-8")) {
             val hint = """
             Consider adding the following to ${System.getShell()?.profile ?: "shell profile"}

--- a/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/diagnostics/JavaDiagnostic.kt
+++ b/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/diagnostics/JavaDiagnostic.kt
@@ -13,8 +13,7 @@ class JavaDiagnostic : Diagnostic("Java") {
         var javaLocation = System.execute("which", "java").output
         val javaVersionCmd = System.execute("java", "-version")
         val javaVersion = if (javaVersionCmd.code == 0) javaVersionCmd.error?.lineSequence()?.firstOrNull() else null
-        //java_home requires empty argument, returns empty response otherwise
-        val systemJavaHome = System.execute("/usr/libexec/java_home", "").output
+        val systemJavaHome = System.execute("/usr/libexec/java_home").output
         val javaHome = System.getEnvVar("JAVA_HOME")
         if (javaLocation == "/usr/bin/java") {
             javaLocation =

--- a/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/entity/System.kt
+++ b/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/entity/System.kt
@@ -47,5 +47,5 @@ expect fun System.getHomeDir(): String
 expect fun System.getEnvVar(name: String): String?
 expect fun System.fileExists(path: String): Boolean
 expect fun System.readFile(path: String): String?
-expect fun System.execute(command: String, vararg args: String): ProcessResult
+expect fun System.execute(command: String, vararg args: String, verbose: Boolean = false): ProcessResult
 expect fun System.findAppsPathsInDirectory(prefix: String, directory: String, recursively: Boolean = false): List<String>


### PR DESCRIPTION
Sometimes (literally sometimes, I see no consistent pattern) when you're trying to execute some shell command using `System.execute()`, it returns with returnCode 65280, and `error == null`, `output == null`. Meanwhile, an `execvp()` [documentation](https://linux.die.net/man/3/execvp) says that the list of arguments must be null-terminated.

Also, added shell commands logging