### PR TITLE
feat: Show development teams

### DIFF
--- a/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/DevelopmentTeams.kt
+++ b/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/DevelopmentTeams.kt
@@ -1,0 +1,60 @@
+package org.jetbrains.kotlin.doctor
+
+import org.jetbrains.kotlin.doctor.entity.System
+
+class DevelopmentTeam(val teamId: String, val teamName: String) {
+    override fun toString(): String = "$teamId ($teamName)"
+}
+
+class DevelopmentTeams(private val system: System) {
+    fun getTeams(): List<DevelopmentTeam> {
+        val allCertsResult = system.execute(
+            "security",
+            "find-certificate",
+            "-c",
+            "Apple Development",
+            "-p",
+            "-a"
+        )
+        val allCerts = allCertsResult.output ?: error("Could not find certificates! ${allCertsResult.rawOutput}")
+        val certs = splitCerts(allCerts)
+        return certs.map {
+            getDevelopmentTeamForCert(it)
+        }
+    }
+
+
+    private fun getDevelopmentTeamForCert(s: String): DevelopmentTeam {
+        val file = system.writeTempFile(s)
+        return getDevelopmentTeamIdFromOpenSslOutput(
+            system.execute(
+                "openssl",
+                "x509",
+                "-noout",
+                "-text",
+                "-in",
+                file
+            ).output ?: error("Couldn't read development certificate!")
+        )
+    }
+
+    private fun getDevelopmentTeamIdFromOpenSslOutput(o: String): DevelopmentTeam {
+        val regex = """OU=(\w{3,}), O=([^,]+)""".toRegex()
+        val res = regex.find(o) ?: error("Could not find development cert!")
+        val (organizationalUnit, organization) = res.destructured
+        return DevelopmentTeam(organizationalUnit, organization)
+    }
+
+    private fun splitCerts(allCertificates: String): List<String> {
+        val certs = mutableListOf<String>()
+        val currentCert = StringBuilder()
+        for (l in allCertificates.lines()) {
+            currentCert.appendLine(l)
+            if ("-----END CERTIFICATE-----" in l) {
+                certs += currentCert.toString()
+                currentCert.clear()
+            }
+        }
+        return certs
+    }
+}

--- a/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/Main.kt
+++ b/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/Main.kt
@@ -4,9 +4,6 @@ import co.touchlab.kermit.CommonWriter
 import co.touchlab.kermit.Logger
 import co.touchlab.kermit.Severity
 import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.parameters.arguments.argument
-import com.github.ajalt.clikt.parameters.arguments.default
-import com.github.ajalt.clikt.parameters.arguments.optional
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import kotlinx.coroutines.runBlocking
@@ -34,6 +31,8 @@ private class Main : CliktCommand(name = "kdoctor") {
     val localCompatibilityJson: String? by option("--compatibilityJson", hidden = true)
     val templateProjectTag: String? by option("--templateProject", hidden = true)
 
+    val showDevelopmentTeams: Boolean by option("--team-ids").flag()
+
     override fun run() {
         Logger.setLogWriters(object : CommonWriter() {
             override fun isLoggable(severity: Severity) = if (isDebug) {
@@ -54,9 +53,19 @@ private class Main : CliktCommand(name = "kdoctor") {
                 println(KDOCTOR_VERSION)
             }
 
+            showDevelopmentTeams -> {
+                println(DevelopmentTeams(getSystem()).getTeams().joinToString("\n"))
+            }
+
             else -> runBlocking {
                 Doctor(getSystem())
-                    .diagnoseKmmEnvironment(isVerbose, isDebug, isExtraDiagnostics, localCompatibilityJson, templateProjectTag)
+                    .diagnoseKmmEnvironment(
+                        isVerbose,
+                        isDebug,
+                        isExtraDiagnostics,
+                        localCompatibilityJson,
+                        templateProjectTag
+                    )
                     .collect { line -> print(line) }
             }
         }


### PR DESCRIPTION
In Compose Multiplatform for iOS, users currently need to go through a bit of a convoluted process to set the `TEAM_ID` in order to run a project on a physical iOS device (https://github.com/SebastianAigner/compose-jb-1/blob/aigner-readme-refresh/experimental/templates/multiplatform-template/README.md#running-with-a-free-personal-team).

Since we already recommend people to download `kdoctor` to make sure their development environment is set up correctly, I thought it might also be a useful tool to provide further information about the development environment.

This PR adds a `--team-ids` flag that shows the local certificates that can be used to sign iOS applications.

```
Sebastian.Aigner@DE-UNIT-1151 debugExecutable % ./kdoctor.kexe --team-ids
3CP3346DXX (Sebastian Prov)
```

If people have multiple Apple Developer certificates on their machine, this will also show them:
```
sebastian.aigner@Munit-452 debugExecutable % ./kdoctor.kexe --team-ids
ZN59W5SJXX (Sebastian Aigner)
KDFZS258XX (Sebastian Dev)
ZN59F6SJXX (Sebastian Aigner)
3CP3F46DXX (Sebastian Prov)
```

Developers can then take that number and put it right into the configuration file for their Compose iOS projects, without having to juggle with `grep` in specific folders or having to full-texts search `xcodeproj` files to get this ID when they're using a free team.

I hope this PR doesn't go too far beyond the scope of `kdoctor`, but seeing how it provides some quality-of-life improvements for Kotlin devs, I think users would find it useful (and we could shorten our tutorials by quite a bit!)