### PR TITLE
Add clearer notes that thsi tool is only for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# KDoctor
+# KDoctor for macOS
 [![JetBrains incubator project](https://jb.gg/badges/incubator.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
 [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Homebrew](https://badgen.net/homebrew/v/kdoctor)](https://formulae.brew.sh/formula/kdoctor)
 
-KDoctor is a command-line tool that helps to set up the environment for [Kotlin Multiplatform Mobile](https://kotlinlang.org/lp/mobile/) app development.
+KDoctor is a command-line tool for macOS that helps to set up the environment for [Kotlin Multiplatform Mobile](https://kotlinlang.org/lp/mobile/) app development.
 
 ![](https://github.com/Kotlin/kdoctor/raw/master/img/screen_1.jpg)
 


### PR DESCRIPTION
The way the tool is presented does look like tools like `flutter doctor`, which work on any platform. If this tool is only for macOS, it should be much more visible. Otherwise it confuses developers.