### PR TITLE
Update Naming to 'Kotlin Multiplatform' per Official Guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Homebrew](https://badgen.net/homebrew/v/kdoctor)](https://formulae.brew.sh/formula/kdoctor)
 
-KDoctor is a command-line tool that helps to set up the environment for [Kotlin Multiplatform Mobile](https://kotlinlang.org/lp/mobile/) app development.
+KDoctor is a command-line tool that helps to set up the environment for mobile app development with [Kotlin Multiplatform](https://kotlinlang.org/lp/multiplatform/).
 
 ![](https://github.com/Kotlin/kdoctor/raw/master/img/screen_1.jpg)
 
@@ -57,13 +57,13 @@ Call KDoctor in the console and wait till it completes the diagnostics
 
 ```
 kdoctor
-Diagnosing Kotlin Multiplatform Mobile environment...
+Diagnosing environment for developing mobile apps with Kotlin Multiplatform...
 ```
 
-Once KDoctor finishes the diagnostics, it yields a report.  If no problems are found your system is ready for Kotlin Multiplatform Mobile development:
+Once KDoctor finishes the diagnostics, it yields a report.  If no problems are found your system is ready for developing mobile apps with Kotlin Multiplatform:
 
 ```
-Your system is ready for Kotlin Multiplatform Mobile Development!
+Your system is ready for mobile app development with Kotlin Multiplatform!
 ```
 
 If KDoctor notifies that there are problems, please review the report:
@@ -140,7 +140,7 @@ Recommendations:
   ➤ IDE doesn't suggest running all tests in file if it contains more than one class
     More details: https://youtrack.jetbrains.com/issue/KTIJ-22078
 Conclusion:
-  ✓ Your system is ready for Kotlin Multiplatform Mobile Development!
+  ✓ Your system is ready for mobile app development with Kotlin Multiplatform!
 ```
 
 ## Issue Tracker

--- a/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/Doctor.kt
+++ b/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/Doctor.kt
@@ -97,7 +97,7 @@ class Doctor(private val system: System) {
             send("    Please check the output for problem description and possible solutions.\n")
         } else {
             val prefix = "  ${DiagnosisResult.Success.color}${DiagnosisResult.Success.symbol}${TextPainter.RESET} "
-            send("${prefix}Your system is ready for Kotlin Multiplatform Mobile Development!\n")
+            send("${prefix}Your system is ready for mobile app development with Kotlin Multiplatform!\n")
         }
     }.buffer(0).flowOn(Dispatchers.Default)
 


### PR DESCRIPTION
This PR updates the naming convention used in KDoctor, aligning it with the [deprecation of the Kotlin Multiplatform Mobile product name](https://blog.jetbrains.com/kotlin/2023/07/update-on-the-name-of-kotlin-multiplatform/), recently announced [by JetBrains](https://twitter.com/kotlin/status/1686018987304292352). 

All references to 'Kotlin Multiplatform Mobile' as a separate product from 'Kotlin Multiplatform' in the code base and documentation have been replaced accordingly. Your review and feedback is appreciated.