### PR TITLE
Update error message for undetected cocoapods

### DIFF
--- a/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/diagnostics/CocoapodsDiagnostic.kt
+++ b/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/diagnostics/CocoapodsDiagnostic.kt
@@ -82,8 +82,8 @@ class CocoapodsDiagnostic(private val system: System) : Diagnostic() {
                 )
             } else {
                 result.addFailure(
-                    "cocoapods not found",
-                    "Get cocoapods from https://guides.cocoapods.org/using/getting-started.html#installation"
+                    "cocoapods not found or installed incorrectly",
+                    "Run 'pod --version' and check output or get cocoapods from https://guides.cocoapods.org/using/getting-started.html#installation"
                 )
             }
             return result.buildWithRecommendation()


### PR DESCRIPTION
The error message for when the cocoapods are not found has been updated. Now, it also accounts for cases when cocoapods could be installed incorrectly. Helpful instructions to check a cocoapod's installation have been added as well.

I personally stumbled upon error mentioned [here](https://stackoverflow.com/questions/77236339/after-updating-cocoapods-to-1-13-0-it-throws-error) and reinstallation suggestion was somewhat misleading