### PR TITLE
Rename KMM to KMP

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Homebrew](https://badgen.net/homebrew/v/kdoctor)](https://formulae.brew.sh/formula/kdoctor)
 
-KDoctor is a command-line tool that helps to set up the environment for [Kotlin Multiplatform Mobile](https://kotlinlang.org/lp/mobile/) app development.
+KDoctor is a command-line tool that helps to set up the environment for [Kotlin Multiplatform](https://kotlinlang.org/lp/mobile/) app development.
 
 ![](https://github.com/Kotlin/kdoctor/raw/master/img/screen_1.jpg)
 
@@ -14,7 +14,7 @@ If something is missed or not configured, KDoctor highlights the problem and sug
 KDoctor runs the following diagnostics:
 * System - checks an operating system version
 * JDK - checks that JDK installation and JAVA_HOME setting
-* Android Studio - checks Android Studio installation, Kotlin and Kotlin Multiplatform Mobile plugins 
+* Android Studio - checks Android Studio installation, Kotlin and Kotlin Multiplatform plugins 
 * Xcode - checks Xcode installation and setup
 * CocoaPods - checks ruby environment and cocoapods gem installation
 
@@ -57,13 +57,13 @@ Call KDoctor in the console and wait till it completes the diagnostics
 
 ```
 kdoctor
-Diagnosing Kotlin Multiplatform Mobile environment...
+Diagnosing Kotlin Multiplatform environment...
 ```
 
-Once KDoctor finishes the diagnostics, it yields a report.  If no problems are found your system is ready for Kotlin Multiplatform Mobile development:
+Once KDoctor finishes the diagnostics, it yields a report.  If no problems are found your system is ready for Kotlin Multiplatform development:
 
 ```
-Your system is ready for Kotlin Multiplatform Mobile Development!
+Your system is ready for Kotlin Multiplatform Development!
 ```
 
 If KDoctor notifies that there are problems, please review the report:
@@ -116,12 +116,12 @@ Environment diagnose:
     Location: /Users/me/Library/Application Support/JetBrains/Toolbox/apps/AndroidStudio/ch-0/222.4459.24.2221.9445173/Android Studio Preview.app
     Bundled Java: openjdk 17.0.4.1 2022-08-12
     Kotlin Plugin: 222-1.8.0-release-AS3739.54
-    Kotlin Multiplatform Mobile Plugin: 1.0.0-SNAPSHOT
+    Kotlin Multiplatform Plugin: 1.0.0-SNAPSHOT
   ➤ Android Studio (AI-221.6008.13.2211.9477386)
     Location: /Users/me/Library/Application Support/JetBrains/Toolbox/apps/AndroidStudio/ch-2/221.6008.13.2211.9477386/Android Studio.app
     Bundled Java: openjdk 11.0.15 2022-04-19
     Kotlin Plugin: 221-1.7.21-release-for-android-studio-AS5591.52
-    Kotlin Multiplatform Mobile Plugin: 0.5.2(221)-3
+    Kotlin Multiplatform Plugin: 0.5.2(221)-3
   i Note that, by default, Android Studio uses bundled JDK for Gradle tasks execution.
     Gradle JDK can be configured in Android Studio Preferences under Build, Execution, Deployment -> Build Tools -> Gradle section
 
@@ -140,7 +140,7 @@ Recommendations:
   ➤ IDE doesn't suggest running all tests in file if it contains more than one class
     More details: https://youtrack.jetbrains.com/issue/KTIJ-22078
 Conclusion:
-  ✓ Your system is ready for Kotlin Multiplatform Mobile Development!
+  ✓ Your system is ready for Kotlin Multiplatform Development!
 ```
 
 ## Issue Tracker

--- a/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/Doctor.kt
+++ b/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/Doctor.kt
@@ -97,7 +97,7 @@ class Doctor(private val system: System) {
             send("    Please check the output for problem description and possible solutions.\n")
         } else {
             val prefix = "  ${DiagnosisResult.Success.color}${DiagnosisResult.Success.symbol}${TextPainter.RESET} "
-            send("${prefix}Your operation system is ready for Kotlin Multiplatform Mobile Development!\n")
+            send("${prefix}Your operation system is ready for Kotlin Multiplatform Development!\n")
         }
     }.buffer(0).flowOn(Dispatchers.Default)
 

--- a/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/diagnostics/AndroidStudioDiagnostic.kt
+++ b/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/diagnostics/AndroidStudioDiagnostic.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.kotlin.doctor.diagnostics
 
 import co.touchlab.kermit.Logger
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import org.jetbrains.kotlin.doctor.entity.*
 
@@ -64,7 +63,8 @@ class AndroidStudioDiagnostic(private val system: System) : Diagnostic() {
         studioInstallations.forEach { app ->
             val androidStudio = AppManager(system, app)
             val kotlinPlugin = androidStudio.getPlugin(AppManager.KOTLIN_PLUGIN)
-            val kmmPlugin = androidStudio.getPlugin(AppManager.KMM_PLUGIN)
+            // TODO: This is why we should not rename "kmm" to "kmp"
+            val kmmPlugin = androidStudio.getPlugin(AppManager.KMP_PLUGIN)
             val embeddedJavaVersion = androidStudio.getEmbeddedJavaVersion()
 
             val message = """
@@ -72,7 +72,7 @@ class AndroidStudioDiagnostic(private val system: System) : Diagnostic() {
                 Location: ${app.location}
                 Bundled Java: ${embeddedJavaVersion ?: "not found"}
                 Kotlin Plugin: ${kotlinPlugin?.version ?: "not installed"}
-                Kotlin Multiplatform Mobile Plugin: ${kmmPlugin?.version ?: "not installed"}
+                Kotlin Multiplatform Plugin: ${kmmPlugin?.version ?: "not installed"}
             """.trimIndent()
             result.addEnvironment(*buildSet {
                 add(EnvironmentPiece.AndroidStudio(app.version))
@@ -97,14 +97,14 @@ class AndroidStudioDiagnostic(private val system: System) : Diagnostic() {
             if (kmmPlugin == null) {
                 result.addWarning(
                     message,
-                    "Install Kotlin Multiplatform Mobile plugin - https://plugins.jetbrains.com/plugin/14936-kotlin-multiplatform-mobile"
+                    "Install Kotlin Multiplatform plugin - https://plugins.jetbrains.com/plugin/14936-kotlin-multiplatform-mobile"
                 )
                 return@forEach
             }
             if (!kmmPlugin.isEnabled) {
                 result.addWarning(
                     message,
-                    "Kotlin Multiplatform Mobile plugin is disabled. Enable Kotlin Multiplatform Mobile in Android Studio settings."
+                    "Kotlin Multiplatform plugin is disabled. Enable Kotlin Multiplatform in Android Studio settings."
                 )
                 return@forEach
             }

--- a/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/entity/Application.kt
+++ b/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/entity/Application.kt
@@ -86,6 +86,7 @@ class AppManager(
 
     companion object {
         const val KOTLIN_PLUGIN = "Kotlin"
-        const val KMM_PLUGIN = "kmm"
+        // TODO: Should not be renamed yet
+        const val KMP_PLUGIN = "kmm"
     }
 }

--- a/kdoctor/src/jvmTest/kotlin/org/jetbrains/kotlin/doctor/diagnostics/AndroidStudioDiagnosticTest.kt
+++ b/kdoctor/src/jvmTest/kotlin/org/jetbrains/kotlin/doctor/diagnostics/AndroidStudioDiagnosticTest.kt
@@ -17,7 +17,7 @@ class AndroidStudioDiagnosticTest {
                 "Location: /Users/my/Library/Application Support/JetBrains/Toolbox/apps/AndroidStudio/ch-0/222.4345.14.2221.9252092/Android Studio Preview.app",
                 "Bundled Java: openjdk version \"11.0.16\" 2022-07-19 LTS",
                 "Kotlin Plugin: 1.7.20",
-                "Kotlin Multiplatform Mobile Plugin: 0.5.0"
+                "Kotlin Multiplatform Plugin: 0.5.0"
             )
             addInfo(
                 "Note that, by default, Android Studio uses bundled JDK for Gradle tasks execution.",
@@ -72,7 +72,7 @@ class AndroidStudioDiagnosticTest {
                 "Location: /Users/my/Library/Application Support/JetBrains/Toolbox/apps/AndroidStudio/ch-0/222.4345.14.2221.9252092/Android Studio Preview.app",
                 "Bundled Java: openjdk version \"11.0.16\" 2022-07-19 LTS",
                 "Kotlin Plugin: 1.7.20",
-                "Kotlin Multiplatform Mobile Plugin: 0.5.0",
+                "Kotlin Multiplatform Plugin: 0.5.0",
                 "Kotlin plugin is disabled. Enable Kotlin in Android Studio settings."
             )
             addInfo(
@@ -90,7 +90,7 @@ class AndroidStudioDiagnosticTest {
     }
 
     @Test
-    fun `check no KMM plugin`() {
+    fun `check no KMP plugin`() {
         val system = object : BaseTestSystem() {
             override fun executeCmd(cmd: String): ProcessResult = when (cmd) {
                 "find $homeDir/Library/Application Support/Google/data/Directory/Name/plugins/kmm/lib -name \"*.jar\"" -> {
@@ -108,8 +108,8 @@ class AndroidStudioDiagnosticTest {
                 "Location: /Users/my/Library/Application Support/JetBrains/Toolbox/apps/AndroidStudio/ch-0/222.4345.14.2221.9252092/Android Studio Preview.app",
                 "Bundled Java: openjdk version \"11.0.16\" 2022-07-19 LTS",
                 "Kotlin Plugin: 1.7.20",
-                "Kotlin Multiplatform Mobile Plugin: not installed",
-                "Install Kotlin Multiplatform Mobile plugin - https://plugins.jetbrains.com/plugin/14936-kotlin-multiplatform-mobile"
+                "Kotlin Multiplatform Plugin: not installed",
+                "Install Kotlin Multiplatform plugin - https://plugins.jetbrains.com/plugin/14936-kotlin-multiplatform-mobile"
             )
             addInfo(
                 "Note that, by default, Android Studio uses bundled JDK for Gradle tasks execution.",
@@ -176,7 +176,7 @@ class AndroidStudioDiagnosticTest {
                 "Location: /Users/my/Library/Application Support/JetBrains/Toolbox/apps/AndroidStudio/ch-0/222.4345.14.2221.9252092/Android Studio Preview.app",
                 "Bundled Java: openjdk version \"11.0.16\" 2022-07-19 LTS",
                 "Kotlin Plugin: not installed",
-                "Kotlin Multiplatform Mobile Plugin: 0.5.0",
+                "Kotlin Multiplatform Plugin: 0.5.0",
                 "Install Kotlin plugin - https://plugins.jetbrains.com/plugin/6954-kotlin"
             )
             addEnvironment(
@@ -188,7 +188,7 @@ class AndroidStudioDiagnosticTest {
                 "Location: /Users/my/Library/Application Support/JetBrains/Toolbox/apps/AndroidStudio/ch-1/213.7172.25.2113.9123335/Android Studio.app",
                 "Bundled Java: not found",
                 "Kotlin Plugin: 1.7.20",
-                "Kotlin Multiplatform Mobile Plugin: 0.5.0"
+                "Kotlin Multiplatform Plugin: 0.5.0"
             )
             addEnvironment(
                 EnvironmentPiece.AndroidStudio(Version("AI-213.7172.25.2113.9123335")),

--- a/kdoctor/src/macosMain/kotlin/org/jetbrains/kotlin/doctor/entity/System.kt
+++ b/kdoctor/src/macosMain/kotlin/org/jetbrains/kotlin/doctor/entity/System.kt
@@ -22,7 +22,7 @@ class MacosSystem : System {
     }
     override val shell: Shell? by lazy {
         getEnvVar("SHELL")?.let { shellPath ->
-            Shell.values().firstOrNull { it.path == shellPath }
+            Shell.entries.firstOrNull { it.path == shellPath }
         }
     }
 


### PR DESCRIPTION
Since Kotlin Multiplatform Mobile (KMM) has been renamed to Kotlin Multiplatform (KMP)
[source](https://blog.jetbrains.com/kotlin/2023/07/update-on-the-name-of-kotlin-multiplatform/)

I renamed everything from KMM and Kotlin multiplatform mobile to KMP and Kotlin multiplatform without affecting the logic, just labeling that is all

because we can't rename everything since the plugin in Android studio is still called KMM so I didn't rename it, yet

Example of running in a successful state:

**Before**

```
./kdoctor 
Environment diagnose (to see all details, use -v option):
[✓] Operation System
[✓] Java
[✓] Android Studio
[✓] Xcode
[✓] CocoaPods

Conclusion:
  ✓ Your operation system is ready for Kotlin Multiplatform Mobile Development!

```

**After**

```
./kdoctor
Environment diagnose (to see all details, use -v option):
[✓] Operation System
[✓] Java
[✓] Android Studio
[✓] Xcode
[✓] CocoaPods

Conclusion:
  ✓ Your operation system is ready for Kotlin Multiplatform Development!

```

I also updated the `README.md` and the tests and the other messages

I also change one additional thing which is not related to the subject

Before

```kotlin
Shell.values().firstOrNull { it.path == shellPath }
```

After

```kotlin
Shell.entries.firstOrNull { it.path == shellPath }
```

Since in Kotlin 1.9.0, it's recommended to use entries instead of values()
in enum classes

there is one thing but I didn't change it
the `diagnose` should be `diagnosis`

it doesn't make much difference at least to me so I didn't update it