### PR TITLE
Support for other platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Homebrew](https://badgen.net/homebrew/v/kdoctor)](https://formulae.brew.sh/formula/kdoctor)
 
-KDoctor is a command-line tool that helps to set up the environment for [Kotlin Multiplatform Mobile](https://kotlinlang.org/lp/mobile/) app development.
+KDoctor is a command-line tool that helps to set up the environment for [Kotlin Multiplatform](https://kotlinlang.org/lp/mobile/) app development.
 
 ![](https://github.com/Kotlin/kdoctor/raw/master/img/screen_1.jpg)
 
@@ -14,7 +14,7 @@ If something is missed or not configured, KDoctor highlights the problem and sug
 KDoctor runs the following diagnostics:
 * System - checks an operating system version
 * JDK - checks that JDK installation and JAVA_HOME setting
-* Android Studio - checks Android Studio installation, Kotlin and Kotlin Multiplatform Mobile plugins 
+* Android Studio - checks Android Studio installation, Kotlin and Kotlin Multiplatform plugins 
 * Xcode - checks Xcode installation and setup
 * CocoaPods - checks ruby environment and cocoapods gem installation
 
@@ -57,13 +57,13 @@ Call KDoctor in the console and wait till it completes the diagnostics
 
 ```
 kdoctor
-Diagnosing Kotlin Multiplatform Mobile environment...
+Diagnosing Kotlin Multiplatform environment...
 ```
 
-Once KDoctor finishes the diagnostics, it yields a report.  If no problems are found your system is ready for Kotlin Multiplatform Mobile development:
+Once KDoctor finishes the diagnostics, it yields a report.  If no problems are found your system is ready for Kotlin Multiplatform development:
 
 ```
-Your system is ready for Kotlin Multiplatform Mobile Development!
+Your system is ready for Kotlin Multiplatform Development!
 ```
 
 If KDoctor notifies that there are problems, please review the report:
@@ -116,12 +116,12 @@ Environment diagnose:
     Location: /Users/me/Library/Application Support/JetBrains/Toolbox/apps/AndroidStudio/ch-0/222.4459.24.2221.9445173/Android Studio Preview.app
     Bundled Java: openjdk 17.0.4.1 2022-08-12
     Kotlin Plugin: 222-1.8.0-release-AS3739.54
-    Kotlin Multiplatform Mobile Plugin: 1.0.0-SNAPSHOT
+    Kotlin Multiplatform Plugin: 1.0.0-SNAPSHOT
   ➤ Android Studio (AI-221.6008.13.2211.9477386)
     Location: /Users/me/Library/Application Support/JetBrains/Toolbox/apps/AndroidStudio/ch-2/221.6008.13.2211.9477386/Android Studio.app
     Bundled Java: openjdk 11.0.15 2022-04-19
     Kotlin Plugin: 221-1.7.21-release-for-android-studio-AS5591.52
-    Kotlin Multiplatform Mobile Plugin: 0.5.2(221)-3
+    Kotlin Multiplatform Plugin: 0.5.2(221)-3
   i Note that, by default, Android Studio uses bundled JDK for Gradle tasks execution.
     Gradle JDK can be configured in Android Studio Preferences under Build, Execution, Deployment -> Build Tools -> Gradle section
 
@@ -140,7 +140,7 @@ Recommendations:
   ➤ IDE doesn't suggest running all tests in file if it contains more than one class
     More details: https://youtrack.jetbrains.com/issue/KTIJ-22078
 Conclusion:
-  ✓ Your system is ready for Kotlin Multiplatform Mobile Development!
+  ✓ Your system is ready for Kotlin Multiplatform Development!
 ```
 
 ## Issue Tracker

--- a/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/Doctor.kt
+++ b/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/Doctor.kt
@@ -97,7 +97,7 @@ class Doctor(private val system: System) {
             send("    Please check the output for problem description and possible solutions.\n")
         } else {
             val prefix = "  ${DiagnosisResult.Success.color}${DiagnosisResult.Success.symbol}${TextPainter.RESET} "
-            send("${prefix}Your operation system is ready for Kotlin Multiplatform Mobile Development!\n")
+            send("${prefix}Your operation system is ready for Kotlin Multiplatform Development!\n")
         }
     }.buffer(0).flowOn(Dispatchers.Default)
 

--- a/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/Doctor.kt
+++ b/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/Doctor.kt
@@ -44,11 +44,12 @@ class Doctor(private val system: System) {
             add(SystemDiagnostic(system).run())
             add(JavaDiagnostic(system).run())
             add(AndroidStudioDiagnostic(system).run())
-            add(XcodeDiagnostic(system).run())
+            if (system.currentOS == OS.MacOS && system.hasXcodeSupport) {
+                add(XcodeDiagnostic(system).run())
+                add(CocoapodsDiagnostic(system).run())
+            }
 
             val mainEnvironmentIsNotReady = this.any { it.conclusion == DiagnosisResult.Failure }
-
-            add(CocoapodsDiagnostic(system).run())
 
             if (extraDiagnostics) {
                 if (mainEnvironmentIsNotReady) {

--- a/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/Main.kt
+++ b/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/Main.kt
@@ -16,10 +16,12 @@ private class Main : CliktCommand(name = "kdoctor") {
         "--version",
         help = "Report a version of KDoctor"
     ).flag()
-    val isVerbose: Boolean by option(
-        "--verbose", "-v",
-        help = "Report an extended information"
-    ).flag()
+    // TODO: Change this
+//    val isVerbose: Boolean by option(
+//        "--verbose", "-v",
+//        help = "Report an extended information"
+//    ).flag()
+    val isVerbose = true
     val isExtraDiagnostics: Boolean by option(
         "--all", "-a",
         help = "Run extra diagnostics such as a build of a synthetic project and an analysis of a project in the current directory"

--- a/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/diagnostics/AndroidStudioDiagnostic.kt
+++ b/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/diagnostics/AndroidStudioDiagnostic.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.kotlin.doctor.diagnostics
 
 import co.touchlab.kermit.Logger
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import org.jetbrains.kotlin.doctor.entity.*
 
@@ -64,7 +63,8 @@ class AndroidStudioDiagnostic(private val system: System) : Diagnostic() {
         studioInstallations.forEach { app ->
             val androidStudio = AppManager(system, app)
             val kotlinPlugin = androidStudio.getPlugin(AppManager.KOTLIN_PLUGIN)
-            val kmmPlugin = androidStudio.getPlugin(AppManager.KMM_PLUGIN)
+            // TODO: This is why we should not rename "kmm" to "kmp"
+            val kmmPlugin = androidStudio.getPlugin(AppManager.KMP_PLUGIN)
             val embeddedJavaVersion = androidStudio.getEmbeddedJavaVersion()
 
             val message = """
@@ -72,7 +72,7 @@ class AndroidStudioDiagnostic(private val system: System) : Diagnostic() {
                 Location: ${app.location}
                 Bundled Java: ${embeddedJavaVersion ?: "not found"}
                 Kotlin Plugin: ${kotlinPlugin?.version ?: "not installed"}
-                Kotlin Multiplatform Mobile Plugin: ${kmmPlugin?.version ?: "not installed"}
+                Kotlin Multiplatform Plugin: ${kmmPlugin?.version ?: "not installed"}
             """.trimIndent()
             result.addEnvironment(*buildSet {
                 add(EnvironmentPiece.AndroidStudio(app.version))
@@ -97,14 +97,14 @@ class AndroidStudioDiagnostic(private val system: System) : Diagnostic() {
             if (kmmPlugin == null) {
                 result.addWarning(
                     message,
-                    "Install Kotlin Multiplatform Mobile plugin - https://plugins.jetbrains.com/plugin/14936-kotlin-multiplatform-mobile"
+                    "Install Kotlin Multiplatform plugin - https://plugins.jetbrains.com/plugin/14936-kotlin-multiplatform-mobile"
                 )
                 return@forEach
             }
             if (!kmmPlugin.isEnabled) {
                 result.addWarning(
                     message,
-                    "Kotlin Multiplatform Mobile plugin is disabled. Enable Kotlin Multiplatform Mobile in Android Studio settings."
+                    "Kotlin Multiplatform plugin is disabled. Enable Kotlin Multiplatform in Android Studio settings."
                 )
                 return@forEach
             }

--- a/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/diagnostics/AndroidStudioDiagnostic.kt
+++ b/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/diagnostics/AndroidStudioDiagnostic.kt
@@ -3,6 +3,7 @@ package org.jetbrains.kotlin.doctor.diagnostics
 import co.touchlab.kermit.Logger
 import kotlinx.serialization.json.Json
 import org.jetbrains.kotlin.doctor.entity.*
+import org.jetbrains.kotlin.doctor.entity.OS.*
 
 class AndroidStudioDiagnostic(private val system: System) : Diagnostic() {
     override val title = "Android Studio"
@@ -10,114 +11,138 @@ class AndroidStudioDiagnostic(private val system: System) : Diagnostic() {
     override fun diagnose(): Diagnosis {
         val result = Diagnosis.Builder(title)
 
-        val paths = mutableSetOf<String>()
-        paths.addAll(system.spotlightFindAppPaths("com.google.android.studio*"))
-        if (paths.isEmpty()) {
-            paths.addAll(system.findAppsPathsInDirectory("Android Studio", "/Applications"))
-            paths.addAll(system.findAppsPathsInDirectory("Android Studio", "${system.homeDir}/Applications"))
-            paths.addAll(
-                system.findAppsPathsInDirectory(
-                    "Android Studio",
-                    "${system.homeDir}/Library/Application Support/JetBrains/Toolbox/apps/AndroidStudio",
-                    true
-                )
-            )
-        }
-        if (paths.isEmpty()) {
-            result.addFailure(
-                "No Android Studio installation found",
-                "Get Android Studio from https://developer.android.com/studio"
-            )
-            return result.build()
-        }
-
-        val jsonFormatter = Json { ignoreUnknownKeys = true }
-        val studioInstallations =
-            paths.mapNotNull { findAndroidStudio(it) }.filter { app -> //filter Toolbox backup versions
-                if (app.location != null && app.location.contains("Toolbox", ignoreCase = true)) {
-                    val channelPath = app.location.substringBeforeLast('/').substringBeforeLast('/')
-                    val historyFile = "$channelPath/.history.json"
-                    val historyJson = system.readFile(historyFile) ?: return@filter true
-                    val history: ToolboxHistory = try {
-                        jsonFormatter.decodeFromString(historyJson)
-                    } catch (e: Exception) {
-                        Logger.e("Parse Toolbox history error: $e", e)
-                        return@filter true
-                    }
-                    val latestBuild = history.history.maxBy { it.timestamp }.item.build
-                    if (app.location.contains(latestBuild)) {
-                        return@filter true
-                    } else {
-                        Logger.d("Skip Toolbox backup: $app")
-                        return@filter false
-                    }
-                } else {
-                    true
+        when (system.currentOS) {
+            MacOS -> {
+                val paths = mutableSetOf<String>()
+                paths.addAll(system.spotlightFindAppPaths("com.google.android.studio*"))
+                if (paths.isEmpty()) {
+                    paths.addAll(system.findAppsPathsInDirectory("Android Studio", "/Applications"))
+                    paths.addAll(system.findAppsPathsInDirectory("Android Studio", "${system.homeDir}/Applications"))
+                    paths.addAll(
+                        system.findAppsPathsInDirectory(
+                            "Android Studio",
+                            "${system.homeDir}/Library/Application Support/JetBrains/Toolbox/apps/AndroidStudio",
+                            true
+                        )
+                    )
                 }
-            }
+                if (paths.isEmpty()) {
+                    result.addFailure(
+                        "No Android Studio installation found",
+                        "Get Android Studio from https://developer.android.com/studio or Jetbrains Toolbox."
+                    )
+                    return result.build()
+                }
 
-        if (studioInstallations.count() > 1) {
-            result.addInfo("Multiple Android Studio installations found")
-        }
+                val jsonFormatter = Json { ignoreUnknownKeys = true }
+                val studioInstallations =
+                    paths.mapNotNull { findAndroidStudio(it) }.filter { app -> //filter Toolbox backup versions
+                        if (app.location != null && app.location.contains("Toolbox", ignoreCase = true)) {
+                            val channelPath = app.location.substringBeforeLast('/').substringBeforeLast('/')
+                            val historyFile = "$channelPath/.history.json"
+                            val historyJson = system.readFile(historyFile) ?: return@filter true
+                            val history: ToolboxHistory = try {
+                                jsonFormatter.decodeFromString(historyJson)
+                            } catch (e: Exception) {
+                                Logger.e("Parse Toolbox history error: $e", e)
+                                return@filter true
+                            }
+                            val latestBuild = history.history.maxBy { it.timestamp }.item.build
+                            if (app.location.contains(latestBuild)) {
+                                return@filter true
+                            } else {
+                                Logger.d("Skip Toolbox backup: $app")
+                                return@filter false
+                            }
+                        } else {
+                            true
+                        }
+                    }
 
-        studioInstallations.forEach { app ->
-            val androidStudio = AppManager(system, app)
-            val kotlinPlugin = androidStudio.getPlugin(AppManager.KOTLIN_PLUGIN)
-            // TODO: This is why we should not rename "kmm" to "kmp"
-            val kmmPlugin = androidStudio.getPlugin(AppManager.KMP_PLUGIN)
-            val embeddedJavaVersion = androidStudio.getEmbeddedJavaVersion()
+                if (studioInstallations.count() > 1) {
+                    result.addInfo("Multiple Android Studio installations found")
+                }
 
-            val message = """
+                studioInstallations.forEach { app ->
+                    val androidStudio = AppManager(system, app)
+                    val kotlinPlugin = androidStudio.getPlugin(AppManager.KOTLIN_PLUGIN)
+                    // TODO: This is why we should not rename value string "kmm" to "kmp" yet
+                    val kmmPlugin = androidStudio.getPlugin(AppManager.KMP_PLUGIN)
+                    val embeddedJavaVersion = androidStudio.getEmbeddedJavaVersion()
+
+                    val message = """
                 Android Studio (${app.version})
                 Location: ${app.location}
                 Bundled Java: ${embeddedJavaVersion ?: "not found"}
                 Kotlin Plugin: ${kotlinPlugin?.version ?: "not installed"}
                 Kotlin Multiplatform Plugin: ${kmmPlugin?.version ?: "not installed"}
             """.trimIndent()
-            result.addEnvironment(*buildSet {
-                add(EnvironmentPiece.AndroidStudio(app.version))
-                if (kotlinPlugin != null) add(EnvironmentPiece.KotlinPlugin(kotlinPlugin.version))
-                if (kmmPlugin != null) add(EnvironmentPiece.KmmPlugin(kmmPlugin.version))
-            }.toTypedArray())
+                    result.addEnvironment(*buildSet {
+                        add(EnvironmentPiece.AndroidStudio(app.version))
+                        if (kotlinPlugin != null) add(EnvironmentPiece.KotlinPlugin(kotlinPlugin.version))
+                        if (kmmPlugin != null) add(EnvironmentPiece.KmmPlugin(kmmPlugin.version))
+                    }.toTypedArray())
 
-            if (kotlinPlugin == null) {
-                result.addFailure(
-                    message,
-                    "Install Kotlin plugin - https://plugins.jetbrains.com/plugin/6954-kotlin"
+                    if (kotlinPlugin == null) {
+                        result.addFailure(
+                            message,
+                            "Install Kotlin plugin - https://plugins.jetbrains.com/plugin/6954-kotlin"
+                        )
+                        return@forEach
+                    }
+                    if (!kotlinPlugin.isEnabled) {
+                        result.addFailure(
+                            message,
+                            "Kotlin plugin is disabled. Enable Kotlin in Android Studio settings."
+                        )
+                        return@forEach
+                    }
+                    if (kmmPlugin == null) {
+                        result.addWarning(
+                            message,
+                            "Install Kotlin Multiplatform plugin - https://plugins.jetbrains.com/plugin/14936-kotlin-multiplatform-mobile"
+                        )
+                        return@forEach
+                    }
+                    if (!kmmPlugin.isEnabled) {
+                        result.addWarning(
+                            message,
+                            "Kotlin Multiplatform plugin is disabled. Enable Kotlin Multiplatform in Android Studio settings."
+                        )
+                        return@forEach
+                    }
+
+                    result.addSuccess(message)
+                    result.setConclusion(DiagnosisResult.Success) //at least one AS is fine
+                }
+
+                result.addInfo(
+                    "Note that, by default, Android Studio uses bundled JDK for Gradle tasks execution.",
+                    "Gradle JDK can be configured in Android Studio Preferences under Build, Execution, Deployment -> Build Tools -> Gradle section"
                 )
-                return@forEach
-            }
-            if (!kotlinPlugin.isEnabled) {
-                result.addFailure(
-                    message,
-                    "Kotlin plugin is disabled. Enable Kotlin in Android Studio settings."
-                )
-                return@forEach
-            }
-            if (kmmPlugin == null) {
-                result.addWarning(
-                    message,
-                    "Install Kotlin Multiplatform plugin - https://plugins.jetbrains.com/plugin/14936-kotlin-multiplatform-mobile"
-                )
-                return@forEach
-            }
-            if (!kmmPlugin.isEnabled) {
-                result.addWarning(
-                    message,
-                    "Kotlin Multiplatform plugin is disabled. Enable Kotlin Multiplatform in Android Studio settings."
-                )
-                return@forEach
+
             }
 
-            result.addSuccess(message)
-            result.setConclusion(DiagnosisResult.Success) //at least one AS is fine
+            Windows -> {
+                val isAndroidStudioInstalled =
+                    system.execute("(gp HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*).DisplayName -Contains \"Android Studio\"")
+                        .output?.equals("True", ignoreCase = true) ?: false
+                println("\n ${system.execute("(gp HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*).DisplayName -Contains \"Android Studio\"")} \n ${system.execute("(gp HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*).DisplayName -Contains \"Android Studio\"")
+                    .output?.equals("True", ignoreCase = true)}")
+                if (isAndroidStudioInstalled) {
+                    result.addSuccess("Android Studio is installed.")
+                } else {
+                    result.addFailure(
+                        "No Android Studio installation found",
+                        "Install/Re-install Android Studio from https://developer.android.com/studio or Jetbrains Toolbox. "
+                    )
+                }
+
+            }
+
+            Linux -> throw NotImplementedError("Linux is not supported yet but we will soon.")
+            UNKNOWN -> throw NotImplementedError("This operating system is not yet supported.")
         }
-
-        result.addInfo(
-            "Note that, by default, Android Studio uses bundled JDK for Gradle tasks execution.",
-            "Gradle JDK can be configured in Android Studio Preferences under Build, Execution, Deployment -> Build Tools -> Gradle section"
-        )
-
         return result.build()
     }
 

--- a/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/diagnostics/CocoapodsDiagnostic.kt
+++ b/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/diagnostics/CocoapodsDiagnostic.kt
@@ -39,10 +39,10 @@ class CocoapodsDiagnostic(private val system: System) : Diagnostic() {
 
         if (ruby.location == "/usr/bin/ruby") {
             val title = "System ruby is currently used"
-            if (system.isUsingM1()) {
+            if (system.isUsingAppleSilicon()) {
                 result.addFailure(
                     title,
-                    "CocoaPods is not compatible with system ruby installation on Apple M1 computers.",
+                    "CocoaPods is not compatible with system ruby installation on Apple Silicon computers.",
                     "Please install ruby via Homebrew, rvm, rbenv or other tool and make it default",
                     "Detailed information: https://stackoverflow.com/questions/64901180/how-to-run-cocoapods-on-apple-silicon-m1/66556339#66556339"
                 )

--- a/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/diagnostics/SystemDiagnostic.kt
+++ b/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/diagnostics/SystemDiagnostic.kt
@@ -10,19 +10,33 @@ class SystemDiagnostic(private val system: System) : Diagnostic() {
         val os = system.currentOS
         val version = system.osVersion
 
-        if (os == OS.MacOS && version != null) {
-            result.addSuccess("Version OS: $os $version", system.cpuInfo?.let { "CPU: $it" }.orEmpty())
-            result.addEnvironment(EnvironmentPiece.Macos(version))
+        when(os) {
+            OS.MacOS -> {
+                if (version != null) {
+                    result.addSuccess("Version OS: $os $version", system.cpuInfo?.let { "CPU: $it" }.orEmpty())
+                    result.addEnvironment(EnvironmentPiece.Macos(version))
 
-            if (system.isUsingRosetta()) {
-                result.addInfo(
-                    "You are currently using Rosetta 2.",
-                    "It may cause some issues while trying to install packages using Homebrew.",
-                    "Consider switching off Rosetta 2 or ignore this message in case you actually need it."
-                )
+                    if (system.isUsingRosetta()) {
+                        result.addInfo(
+                            "You are currently using Rosetta 2.",
+                            "It may cause some issues while trying to install packages using Homebrew.",
+                            "Consider switching off Rosetta 2 or ignore this message in case you actually need it."
+                        )
+                    }
+                    return result.build()
+                }
+                result.addFailure("OS: $os $version")
             }
-        } else {
-            result.addFailure("OS: $os $version")
+            OS.Windows -> {
+                result.addSuccess("Version OS: $os $version", system.cpuInfo?.let { "CPU: $it" }.orEmpty())
+            }
+            OS.Linux -> {
+                result.addSuccess("Version OS: $os $version", system.cpuInfo?.let { "CPU: $it" }.orEmpty())
+            }
+
+            else -> {
+                result.addFailure("OS: $os $version")
+            }
         }
         return result.build()
     }

--- a/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/entity/Application.kt
+++ b/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/entity/Application.kt
@@ -86,6 +86,7 @@ class AppManager(
 
     companion object {
         const val KOTLIN_PLUGIN = "Kotlin"
-        const val KMM_PLUGIN = "kmm"
+        // TODO: Should not be renamed yet
+        const val KMP_PLUGIN = "kmm"
     }
 }

--- a/kdoctor/src/jvmMain/kotlin/org/jetbrains/kotlin/doctor/JvmMain.kt
+++ b/kdoctor/src/jvmMain/kotlin/org/jetbrains/kotlin/doctor/JvmMain.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.kotlin.doctor
 
+import org.jetbrains.kotlin.doctor.entity.JvmSystem
 import org.jetbrains.kotlin.doctor.entity.System
 
-actual fun getSystem(): System = TODO("JVM target is only for unit tests")
+actual fun getSystem(): System = JvmSystem()

--- a/kdoctor/src/jvmMain/kotlin/org/jetbrains/kotlin/doctor/entity/System.kt
+++ b/kdoctor/src/jvmMain/kotlin/org/jetbrains/kotlin/doctor/entity/System.kt
@@ -1,0 +1,90 @@
+package org.jetbrains.kotlin.doctor.entity
+
+import co.touchlab.kermit.Logger
+import org.jetbrains.kotlin.doctor.entity.OS.*
+import java.io.File
+
+class JvmSystem : System {
+    override val osVersion: Version?
+        get() {
+            val osVersion = java.lang.System.getProperty("os.version") ?: return null
+            return Version(
+                version = osVersion,
+            )
+        }
+    override val currentOS: OS
+        get() {
+            val osName = java.lang.System.getProperty("os.name").lowercase()
+            if (osName.startsWith("win")) {
+                return Windows
+            }
+            if (osName.startsWith("mac")) {
+                return MacOS
+            }
+            if (osName.startsWith("linux")) {
+                return Linux
+            }
+//            throw NotImplementedError(
+//                "The operating system $osName is not supported. please send this report on Github",
+//            )
+            return UNKNOWN
+        }
+    override val cpuInfo: String?
+        get() = java.lang.System.getProperty("sun.cpu.isalist")
+    override val homeDir: String
+        get() = java.lang.System.getProperty("user.home")
+    override val shell: Shell?
+        get() = null
+    override val hasXcodeSupport: Boolean
+        get() = false
+
+    override fun getEnvVar(name: String): String? {
+        return java.lang.System.getProperty(name) ?: null
+    }
+
+    override fun execute(command: String, vararg args: String): ProcessResult {
+        val cmd = mutableListOf<String>().apply {
+            add(command)
+            addAll(args)
+        }.joinToString(separator = " ") { it.replace(" ", "\\ ") }
+        Logger.d("Execute '$cmd'")
+        val runtime = Runtime.getRuntime()
+        return try {
+            val processResult = runtime.exec(cmd)
+            ProcessResult(processResult.waitFor() , processResult.inputStream.reader().readText())
+        } catch (e: Exception) {
+            Logger.d("Error while execute command: '$cmd'\n with exception $e")
+            ProcessResult(-1 ,e.message)
+        }
+    }
+
+    override fun fileExists(path: String): Boolean {
+        return File(path).exists()
+    }
+
+    override fun readFile(path: String): String? {
+        return try {
+            File(path).readText()
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    override fun writeTempFile(content: String): String {
+        return ""
+    }
+
+    override fun readArchivedFile(pathToArchive: String, pathToFile: String): String? {
+        return null
+    }
+
+    override fun findAppsPathsInDirectory(prefix: String, directory: String, recursively: Boolean): List<String> {
+        val paths = mutableListOf<String>()
+        val filePaths = File(directory).listFiles() ?: return paths
+        for (filePath in filePaths) {
+            paths.add(filePath.path)
+        }
+        return paths
+    }
+
+}

--- a/kdoctor/src/jvmTest/kotlin/org/jetbrains/kotlin/doctor/diagnostics/AndroidStudioDiagnosticTest.kt
+++ b/kdoctor/src/jvmTest/kotlin/org/jetbrains/kotlin/doctor/diagnostics/AndroidStudioDiagnosticTest.kt
@@ -49,7 +49,7 @@ class AndroidStudioDiagnosticTest {
         val expected = Diagnosis.Builder("Android Studio").apply {
             addFailure(
                 "No Android Studio installation found",
-                "Get Android Studio from https://developer.android.com/studio"
+                "Get Android Studio from https://developer.android.com/studio or Jetbrains Toolbox."
             )
         }.build()
 

--- a/kdoctor/src/jvmTest/kotlin/org/jetbrains/kotlin/doctor/diagnostics/AndroidStudioDiagnosticTest.kt
+++ b/kdoctor/src/jvmTest/kotlin/org/jetbrains/kotlin/doctor/diagnostics/AndroidStudioDiagnosticTest.kt
@@ -17,7 +17,7 @@ class AndroidStudioDiagnosticTest {
                 "Location: /Users/my/Library/Application Support/JetBrains/Toolbox/apps/AndroidStudio/ch-0/222.4345.14.2221.9252092/Android Studio Preview.app",
                 "Bundled Java: openjdk version \"11.0.16\" 2022-07-19 LTS",
                 "Kotlin Plugin: 1.7.20",
-                "Kotlin Multiplatform Mobile Plugin: 0.5.0"
+                "Kotlin Multiplatform Plugin: 0.5.0"
             )
             addInfo(
                 "Note that, by default, Android Studio uses bundled JDK for Gradle tasks execution.",
@@ -72,7 +72,7 @@ class AndroidStudioDiagnosticTest {
                 "Location: /Users/my/Library/Application Support/JetBrains/Toolbox/apps/AndroidStudio/ch-0/222.4345.14.2221.9252092/Android Studio Preview.app",
                 "Bundled Java: openjdk version \"11.0.16\" 2022-07-19 LTS",
                 "Kotlin Plugin: 1.7.20",
-                "Kotlin Multiplatform Mobile Plugin: 0.5.0",
+                "Kotlin Multiplatform Plugin: 0.5.0",
                 "Kotlin plugin is disabled. Enable Kotlin in Android Studio settings."
             )
             addInfo(
@@ -90,7 +90,7 @@ class AndroidStudioDiagnosticTest {
     }
 
     @Test
-    fun `check no KMM plugin`() {
+    fun `check no KMP plugin`() {
         val system = object : BaseTestSystem() {
             override fun executeCmd(cmd: String): ProcessResult = when (cmd) {
                 "find $homeDir/Library/Application Support/Google/data/Directory/Name/plugins/kmm/lib -name \"*.jar\"" -> {
@@ -108,8 +108,8 @@ class AndroidStudioDiagnosticTest {
                 "Location: /Users/my/Library/Application Support/JetBrains/Toolbox/apps/AndroidStudio/ch-0/222.4345.14.2221.9252092/Android Studio Preview.app",
                 "Bundled Java: openjdk version \"11.0.16\" 2022-07-19 LTS",
                 "Kotlin Plugin: 1.7.20",
-                "Kotlin Multiplatform Mobile Plugin: not installed",
-                "Install Kotlin Multiplatform Mobile plugin - https://plugins.jetbrains.com/plugin/14936-kotlin-multiplatform-mobile"
+                "Kotlin Multiplatform Plugin: not installed",
+                "Install Kotlin Multiplatform plugin - https://plugins.jetbrains.com/plugin/14936-kotlin-multiplatform-mobile"
             )
             addInfo(
                 "Note that, by default, Android Studio uses bundled JDK for Gradle tasks execution.",
@@ -176,7 +176,7 @@ class AndroidStudioDiagnosticTest {
                 "Location: /Users/my/Library/Application Support/JetBrains/Toolbox/apps/AndroidStudio/ch-0/222.4345.14.2221.9252092/Android Studio Preview.app",
                 "Bundled Java: openjdk version \"11.0.16\" 2022-07-19 LTS",
                 "Kotlin Plugin: not installed",
-                "Kotlin Multiplatform Mobile Plugin: 0.5.0",
+                "Kotlin Multiplatform Plugin: 0.5.0",
                 "Install Kotlin plugin - https://plugins.jetbrains.com/plugin/6954-kotlin"
             )
             addEnvironment(
@@ -188,7 +188,7 @@ class AndroidStudioDiagnosticTest {
                 "Location: /Users/my/Library/Application Support/JetBrains/Toolbox/apps/AndroidStudio/ch-1/213.7172.25.2113.9123335/Android Studio.app",
                 "Bundled Java: not found",
                 "Kotlin Plugin: 1.7.20",
-                "Kotlin Multiplatform Mobile Plugin: 0.5.0"
+                "Kotlin Multiplatform Plugin: 0.5.0"
             )
             addEnvironment(
                 EnvironmentPiece.AndroidStudio(Version("AI-213.7172.25.2113.9123335")),

--- a/kdoctor/src/jvmTest/kotlin/org/jetbrains/kotlin/doctor/diagnostics/BaseTestSystem.kt
+++ b/kdoctor/src/jvmTest/kotlin/org/jetbrains/kotlin/doctor/diagnostics/BaseTestSystem.kt
@@ -9,6 +9,8 @@ open class BaseTestSystem : System {
     override val cpuInfo: String? = "test_cpu"
     override val homeDir: String = "/Users/my"
     override val shell: Shell? = Shell.Zsh
+    override val hasXcodeSupport: Boolean
+        get() = false
 
     open val testProjectPath: String = "./test/my_project"
     open val testTempFile: String get() = "$testProjectPath/temp.file"
@@ -30,7 +32,7 @@ open class BaseTestSystem : System {
             "which java" -> {
                 "$homeDir/.sdkman/candidates/java/current/bin/java"
             }
-            "java -version" -> {
+            "java --version" -> {
                 """
                     openjdk version "11.0.16" 2022-07-19 LTS
                     OpenJDK Runtime Environment Corretto-11.0.16.8.1 (build 11.0.16+8-LTS)

--- a/kdoctor/src/jvmTest/kotlin/org/jetbrains/kotlin/doctor/diagnostics/CocoapodsDiagnosticTest.kt
+++ b/kdoctor/src/jvmTest/kotlin/org/jetbrains/kotlin/doctor/diagnostics/CocoapodsDiagnosticTest.kt
@@ -115,7 +115,7 @@ class CocoapodsDiagnosticTest {
             )
             addFailure(
                 "System ruby is currently used",
-                "CocoaPods is not compatible with system ruby installation on Apple M1 computers.",
+                "CocoaPods is not compatible with system ruby installation on Apple Silicon computers.",
                 "Please install ruby via Homebrew, rvm, rbenv or other tool and make it default",
                 "Detailed information: https://stackoverflow.com/questions/64901180/how-to-run-cocoapods-on-apple-silicon-m1/66556339#66556339"
             )

--- a/kdoctor/src/jvmTest/kotlin/org/jetbrains/kotlin/doctor/diagnostics/SystemDiagnosticTest.kt
+++ b/kdoctor/src/jvmTest/kotlin/org/jetbrains/kotlin/doctor/diagnostics/SystemDiagnosticTest.kt
@@ -59,13 +59,13 @@ internal class SystemDiagnosticTest {
     @Test
     fun `check invalid OS`() {
         val system = object : BaseTestSystem() {
-            override val currentOS = OS.Linux
+            override val currentOS = OS.UNKNOWN
         }
         val diagnose = SystemDiagnostic(system).diagnose()
 
         val expected = Diagnosis.Builder("Operation System").apply {
             addFailure(
-                "OS: Linux 42.777"
+                "OS: Unknown 42.777"
             )
         }.build()
 

--- a/kdoctor/src/macosMain/kotlin/org/jetbrains/kotlin/doctor/entity/System.kt
+++ b/kdoctor/src/macosMain/kotlin/org/jetbrains/kotlin/doctor/entity/System.kt
@@ -22,7 +22,7 @@ class MacosSystem : System {
     }
     override val shell: Shell? by lazy {
         getEnvVar("SHELL")?.let { shellPath ->
-            Shell.values().firstOrNull { it.path == shellPath }
+            Shell.entries.firstOrNull { it.path == shellPath }
         }
     }
 

--- a/kdoctor/src/macosMain/kotlin/org/jetbrains/kotlin/doctor/entity/System.kt
+++ b/kdoctor/src/macosMain/kotlin/org/jetbrains/kotlin/doctor/entity/System.kt
@@ -25,6 +25,8 @@ class MacosSystem : System {
             Shell.entries.firstOrNull { it.path == shellPath }
         }
     }
+    override val hasXcodeSupport: Boolean
+        get() = true
 
     override fun getEnvVar(name: String): String? = getenv(name)?.toKString()
 


### PR DESCRIPTION
This pull request adds support for Windows and Linux

It's not complete yet and it needs more changes and refactoring and more testing
I would like to complete this change but I need to know if the Kotlin team is interested in this change because the support for Windows and Linux is pretty easy and I'm sure there is a reason why the Kotlin team decided to add support only for macOS but in order for KMP to gain more popularity I think it's a good idea to add support for other platforms because KMP was originally called Kotlin multiplatform mobile so it makes sense to use it only on macOS while it's still useful in other platforms in case we want to add support for iOS but now the project is for all platforms so it makes sense to add support of the KMP doctor for all platforms

In order to complete this I need to refactor and change some things, I will still follow the convention and style of Kotlin so it's still readable and maintainable as it was before

Until now I haven't made many changes but please let me know if you are interested