### PR TITLE
KMT-1463: Update KMM_PLUGIN constant to include '-plugin'

### DIFF
--- a/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/entity/Application.kt
+++ b/kdoctor/src/commonMain/kotlin/org/jetbrains/kotlin/doctor/entity/Application.kt
@@ -86,6 +86,6 @@ class AppManager(
 
     companion object {
         const val KOTLIN_PLUGIN = "Kotlin"
-        const val KMM_PLUGIN = "kmm"
+        const val KMM_PLUGIN = "kmm-plugin"
     }
 }


### PR DESCRIPTION
Fixes: https://youtrack.jetbrains.com/projects/KMT/issues/KMT-1463/KDoctor-does-not-recognize-that-Multiplatform-plugin-is-installed

<img width="277" height="184" alt="image" src="https://github.com/user-attachments/assets/a6d268fb-a8cb-45a8-8403-93d6db35f4d8" />
